### PR TITLE
Fix issue where the number of source location could overflow

### DIFF
--- a/Source/DebugEngine.DebugInfo.pas
+++ b/Source/DebugEngine.DebugInfo.pas
@@ -89,7 +89,7 @@ type
     NumberOfSegments: Byte; // Number of segments.
     NumberOfUnits: Word; // Number of units.
     NumberOfSymbols: DWORD; // Number of Symbols.
-    NumberOfSourceLocations: Word; // Number of source locations.
+    NumberOfSourceLocations: DWORD; // Number of source locations.
     OffsetToUnits: Cardinal; // Offset from header to first unit struct (TSMapUnit).
     OffsetToSymbols: Cardinal; // Offset from header to first symbol struct (TSMapSymbol).
     OffsetToSourceLocations: Cardinal; // Offset from header to first source location struct (TSMapSourceLocation).


### PR DESCRIPTION
In smap file headers, the number of source locations is a 2-byte integer.
In projects with more than 65,535 source locations, this can cause incorrect filenames to appear in stack traces.

This PR changes `TSMapHeader.NumberOfSourceLocations` from a `Word` to a `DWORD`.