### PR TITLE
Fix issue where NumberOfLineNumbers overflows for huge files

### DIFF
--- a/Source/DebugEngine.DebugInfo.pas
+++ b/Source/DebugEngine.DebugInfo.pas
@@ -129,7 +129,7 @@ type
 
   TSMapSourceLocation = packed record
     SegId: Byte;
-    NumberOfLineNumbers: Word;
+    NumberOfLineNumbers: DWORD;
     SourceLocationLength: Word;
     SourceLocation: array [0 .. 0] of SMapChar;
   end;


### PR DESCRIPTION
In smap source locations, the number of line numbers is a 2-byte integer.
In files with more than 65,535 line numbers, the field overflows and causes `TDebugInfoSMap.ProcessMap` to fail.

This PR changes TSMapHeader.NumberOfSourceLocations from a Word to a DWORD.